### PR TITLE
Add span categories

### DIFF
--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -65,8 +65,8 @@ defmodule Appsignal.Plug do
   @doc false
   def set_conn_data(span, conn) do
     span
-    |> @span.set_attribute("appsignal:category", "call.plug")
     |> set_name(conn)
+    |> set_category(conn)
     |> set_params(conn)
     |> set_sample_data(conn)
     |> set_session_data(conn)
@@ -112,6 +112,14 @@ defmodule Appsignal.Plug do
 
   defp set_name(span, _conn) do
     span
+  end
+
+  defp set_category(span, %Plug.Conn{private: %{phoenix_endpoint: _endpoint}}) do
+    @span.set_attribute(span, "appsignal:category", "call.phoenix")
+  end
+
+  defp set_category(span, _conn) do
+    @span.set_attribute(span, "appsignal:category", "call.plug")
   end
 
   defp set_params(span, conn) do

--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -65,6 +65,7 @@ defmodule Appsignal.Plug do
   @doc false
   def set_conn_data(span, conn) do
     span
+    |> @span.set_attribute("appsignal:category", "call.plug")
     |> set_name(conn)
     |> set_params(conn)
     |> set_sample_data(conn)

--- a/test/appsignal_plug_test.exs
+++ b/test/appsignal_plug_test.exs
@@ -103,6 +103,10 @@ defmodule Appsignal.PlugTest do
       assert {:ok, [{%Span{}, "GET /"}]} = Test.Span.get(:set_name)
     end
 
+    test "sets the span's category" do
+      assert {:ok, [{%Span{}, "appsignal:category", "call.plug"}]} = Test.Span.get(:set_attribute)
+    end
+
     test "sets the span's sample data" do
       assert sample_data("environment", %{
                "host" => "www.example.com",

--- a/test/appsignal_plug_test.exs
+++ b/test/appsignal_plug_test.exs
@@ -364,6 +364,21 @@ defmodule Appsignal.PlugTest do
       assert {:ok, [{^span, "GET /"}]} = Test.Span.get(:set_name)
     end
 
+    test "sets the span's category", %{span: span} do
+      assert Appsignal.Plug.set_conn_data(span, %Plug.Conn{}) == span
+
+      assert {:ok, [{^span, "appsignal:category", "call.plug"}]} = Test.Span.get(:set_attribute)
+    end
+
+    test "sets the span's category, with a Phoenix conn", %{span: span} do
+      assert Appsignal.Plug.set_conn_data(span, %Plug.Conn{
+               private: %{phoenix_endpoint: Appsignal.Endpoint}
+             }) == span
+
+      assert {:ok, [{^span, "appsignal:category", "call.phoenix"}]} =
+               Test.Span.get(:set_attribute)
+    end
+
     test "ignores Phoenix conns", %{span: span} do
       assert Appsignal.Plug.set_conn_data(span, %Plug.Conn{
                method: "GET",


### PR DESCRIPTION
As described in https://github.com/appsignal/integration-guide/pull/14, this patch adds categories to handle span grouping in the processor.