### PR TITLE
Throw warning when including Appsignal.Plug twice

### DIFF
--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -54,7 +54,7 @@ defmodule Appsignal.Plug do
           else
             conn ->
               Appsignal.Plug.set_conn_data(span, conn)
-              conn
+              Plug.Conn.put_private(conn, :appsignal_plug_instrumented, true)
           end
         end)
       end

--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -35,6 +35,14 @@ defmodule Appsignal.Plug do
 
       use Plug.ErrorHandler
 
+      def call(%Plug.Conn{private: %{appsignal_plug_instrumented: true}} = conn, opts) do
+        Logger.warn(
+          "Appsignal.Plug was included twice, disabling Appsignal.Plug. Please only `use Appsignal.Plug` once."
+        )
+
+        super(conn, opts)
+      end
+
       def call(conn, opts) do
         Appsignal.instrument(fn span ->
           @span.set_namespace(span, "http_request")

--- a/test/appsignal_plug_test.exs
+++ b/test/appsignal_plug_test.exs
@@ -129,6 +129,10 @@ defmodule Appsignal.PlugTest do
     test "closes the span" do
       assert {:ok, [{%Span{}}]} = Test.Tracer.get(:close_span)
     end
+
+    test "sets the :appsignal_plug_instrumented flag", %{conn: conn} do
+      assert %Plug.Conn{private: %{appsignal_plug_instrumented: true}} = conn
+    end
   end
 
   describe "GET /users/:id" do


### PR DESCRIPTION
As I proposed as a solution to a solved [support issue](https://app.intercom.com/a/apps/yzor8gyw/inbox/inbox/540654/conversations/16410700002289) (private Intercom link), this patch throws a warning and disables `Appsignal.Plug` when calling `use Appsignal.Plug` twice.