### PR TITLE
Add documentation for Appsignal.Plug.put_name/2

### DIFF
--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -63,7 +63,32 @@ defmodule Appsignal.Plug do
     end
   end
 
-  @doc false
+  @doc """
+  Adds an `:appsignal_name` to the `Plug.Conn`, to overwrite the root
+  `Appsignal.Span`'s name.
+
+  ## Examples
+
+      iex> Appsignal.Plug.put_name(%Plug.Conn{}, "AppsignalPlugExample#index")
+      %Plug.Conn{private: %{appsignal_name: "AppsignalPlugExample#index"}}
+
+  In a Plug app, call `Appsignal.Plug.put_name/2` on the returned `Plug.Conn`
+  struct:
+
+      defmodule AppsignalPlugExample do
+        use Plug.Router
+        use Appsignal.Plug
+
+        plug(:match)
+        plug(:dispatch)
+
+        get "/" do
+          conn
+          |> Appsignal.Plug.put_name("AppsignalPlugExample#index")
+          |> send_resp(200, "Welcome")
+        end
+      end
+  """
   def put_name(%Plug.Conn{} = conn, name) do
     Plug.Conn.put_private(conn, :appsignal_name, name)
   end

--- a/test/appsignal_plug_test.exs
+++ b/test/appsignal_plug_test.exs
@@ -81,6 +81,7 @@ defmodule Appsignal.PlugTest do
   use ExUnit.Case
   use Plug.Test
   alias Appsignal.{Span, Test}
+  doctest Appsignal.Plug
 
   setup do
     Test.Tracer.start_link()


### PR DESCRIPTION
As asked in https://github.com/appsignal/appsignal-elixir/issues/581, this patch adds a code sample and a dockets for `Appsignal.Plug.put_name/2`.