### PR TITLE
Explicitly ignore return from span functions in Appsignal.Plug 

### DIFF
--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -45,13 +45,15 @@ defmodule Appsignal.Plug do
 
       def call(conn, opts) do
         Appsignal.instrument(fn span ->
-          @span.set_namespace(span, "http_request")
+          _ = @span.set_namespace(span, "http_request")
 
           try do
             super(conn, opts)
           catch
             kind, reason ->
               stack = __STACKTRACE__
+
+              _ = span
 
               span
               |> Appsignal.Plug.handle_error(kind, reason, stack, conn)
@@ -61,7 +63,7 @@ defmodule Appsignal.Plug do
               :erlang.raise(kind, reason, stack)
           else
             conn ->
-              Appsignal.Plug.set_conn_data(span, conn)
+              _ = Appsignal.Plug.set_conn_data(span, conn)
               Plug.Conn.put_private(conn, :appsignal_plug_instrumented, true)
           end
         end)

--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -53,11 +53,10 @@ defmodule Appsignal.Plug do
             kind, reason ->
               stack = __STACKTRACE__
 
-              _ = span
-
-              span
-              |> Appsignal.Plug.handle_error(kind, reason, stack, conn)
-              |> @tracer.close_span()
+              _ =
+                span
+                |> Appsignal.Plug.handle_error(kind, reason, stack, conn)
+                |> @tracer.close_span()
 
               @tracer.ignore()
               :erlang.raise(kind, reason, stack)

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,8 @@ defmodule Appsignal.Plug.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: [
-        plt_file: {:no_warn, "priv/plts/dialyzer.plt"}
+        plt_file: {:no_warn, "priv/plts/dialyzer.plt"},
+        flags: ["-Wunmatched_returns", "-Werror_handling", "-Wunderspecs"]
       ]
     ]
   end


### PR DESCRIPTION
Since the `Span` functions take and return `Span`s and `nil`s, we don't care
about the return value here, as either case is accounted for.

Part of closing https://github.com/appsignal/appsignal-elixir-phoenix/issues/5.