### PR TITLE
Add status and request_id and restore headers in Appsignal.Metadata

### DIFF
--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -137,9 +137,11 @@ defmodule Appsignal.Plug do
 
   @doc false
   def handle_error(span, kind, reason, stack, conn) do
+    conn_with_status = Plug.Conn.put_status(conn, Plug.Exception.status(reason))
+
     span
     |> @span.add_error(kind, reason, stack)
-    |> set_conn_data(conn)
+    |> set_conn_data(conn_with_status)
   end
 
   defp set_name(span, %Plug.Conn{private: %{appsignal_name: name}}) do

--- a/lib/appsignal_plug/metadata.ex
+++ b/lib/appsignal_plug/metadata.ex
@@ -1,15 +1,25 @@
 defimpl Appsignal.Metadata, for: Plug.Conn do
-  def metadata(%Plug.Conn{
-        host: host,
-        method: method,
-        request_path: request_path,
-        port: port
-      }) do
+  def metadata(
+        %Plug.Conn{
+          host: host,
+          method: method,
+          request_path: request_path,
+          port: port,
+          status: status
+        } = conn
+      ) do
+    request_id =
+      conn
+      |> Plug.Conn.get_resp_header("x-request-id")
+      |> List.first()
+
     %{
       "host" => host,
       "method" => method,
       "request_path" => request_path,
-      "port" => port
+      "port" => port,
+      "request_id" => request_id,
+      "status" => status
     }
   end
 end

--- a/test/appsignal_plug_test.exs
+++ b/test/appsignal_plug_test.exs
@@ -1,8 +1,19 @@
+defmodule RequestId do
+  def init(_opts) do
+    :ok
+  end
+
+  def call(conn, _opts) do
+    Plug.Conn.put_resp_header(conn, "x-request-id", "request_id")
+  end
+end
+
 defmodule PlugWithAppsignal do
   use Plug.Router
   use Appsignal.Plug
   use Plug.ErrorHandler
 
+  plug(RequestId)
   plug(:match)
   plug(:dispatch)
 
@@ -123,7 +134,9 @@ defmodule Appsignal.PlugTest do
                "host" => "www.example.com",
                "method" => "GET",
                "port" => 80,
-               "request_path" => "/"
+               "request_path" => "/",
+               "status" => 200,
+               "request_id" => "request_id"
              })
     end
 
@@ -196,7 +209,9 @@ defmodule Appsignal.PlugTest do
                "host" => "www.example.com",
                "method" => "GET",
                "port" => 80,
-               "request_path" => "/instrumentation"
+               "request_path" => "/instrumentation",
+               "status" => 200,
+               "request_id" => "request_id"
              })
     end
 
@@ -227,7 +242,9 @@ defmodule Appsignal.PlugTest do
                "host" => "www.example.com",
                "method" => "GET",
                "port" => 80,
-               "request_path" => "/exception"
+               "request_path" => "/exception",
+               "status" => nil,
+               "request_id" => "request_id"
              })
     end
 

--- a/test/appsignal_plug_test.exs
+++ b/test/appsignal_plug_test.exs
@@ -136,7 +136,8 @@ defmodule Appsignal.PlugTest do
                "port" => 80,
                "request_path" => "/",
                "status" => 200,
-               "request_id" => "request_id"
+               "request_id" => "request_id",
+               "req_headers.accept" => "text/html"
              })
     end
 
@@ -211,7 +212,8 @@ defmodule Appsignal.PlugTest do
                "port" => 80,
                "request_path" => "/instrumentation",
                "status" => 200,
-               "request_id" => "request_id"
+               "request_id" => "request_id",
+               "req_headers.accept" => "text/html"
              })
     end
 
@@ -244,7 +246,8 @@ defmodule Appsignal.PlugTest do
                "port" => 80,
                "request_path" => "/exception",
                "status" => 500,
-               "request_id" => "request_id"
+               "request_id" => "request_id",
+               "req_headers.accept" => "text/html"
              })
     end
 
@@ -487,7 +490,10 @@ defmodule Appsignal.PlugTest do
   end
 
   defp get(path, params_or_body \\ nil) do
-    conn = conn(:get, path, params_or_body)
+    conn =
+      :get
+      |> conn(path, params_or_body)
+      |> put_req_header("accept", "text/html")
 
     try do
       [conn: PlugWithAppsignal.call(conn, [])]

--- a/test/appsignal_plug_test.exs
+++ b/test/appsignal_plug_test.exs
@@ -243,7 +243,7 @@ defmodule Appsignal.PlugTest do
                "method" => "GET",
                "port" => 80,
                "request_path" => "/exception",
-               "status" => nil,
+               "status" => 500,
                "request_id" => "request_id"
              })
     end


### PR DESCRIPTION
While moving to `Appsignal.Metadata` in 2.x, we dropped part of the extracted metadata and headers extracted in our Plug instrumentation. This patch addd these back to return to what we reported in 1.x.

Fixes https://3.basecamp.com/4738529/buckets/18205087/messages/3239065640#__recording_3242826417, as reported in https://app.intercom.com/a/apps/yzor8gyw/inbox/inbox/4356044/conversations/16410700017705. This patch is planned to be released as 2.0.2.