### PR TITLE
Drop all errors with a plug_status < 500, not just WrapperErrors

### DIFF
--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -116,23 +116,16 @@ defmodule Appsignal.Plug do
   def handle_error(
         span,
         :error,
-        %Plug.Conn.WrapperError{reason: %{plug_status: status}},
-        _stack,
-        _conn
-      )
-      when status < 500 do
-    span
-  end
-
-  @doc false
-  def handle_error(
-        span,
-        :error,
         %Plug.Conn.WrapperError{conn: conn, reason: wrapped_reason, stack: stack},
         _stack,
         _conn
       ) do
     handle_error(span, :error, wrapped_reason, stack, conn)
+  end
+
+  @doc false
+  def handle_error(span, _kind, %{plug_status: status}, _stack, _conn) when status < 500 do
+    span
   end
 
   @doc false


### PR DESCRIPTION
Closes https://github.com/appsignal/support/issues/103.

Instead of ignoring Plug.Conn.WrapperErrors with a status lower than 500, this
patch drops all errors with a plug_status lower than 500.

Merging this patch should fix
https://appsignal.semaphoreci.com/workflows/c367a8de-a249-40b7-a3a4-b1198c6fb994?pipeline_id=fbcd7ebe-02eb-4c5c-b752-58306c8c0f83
on appsignal_phoenix.