### PR TITLE
Handle conns with nil `request_headers` attributes

### DIFF
--- a/lib/appsignal_plug/metadata.ex
+++ b/lib/appsignal_plug/metadata.ex
@@ -28,10 +28,20 @@ defimpl Appsignal.Metadata, for: Plug.Conn do
   end
 
   defp headers(req_headers) do
-    for {key, value} <- req_headers,
-        key in Appsignal.Config.request_headers() do
-      {"req_headers.#{key}", value}
-    end
-    |> Enum.into(%{})
+    headers(req_headers, %{})
+  end
+
+  defp headers([{key, value} | tail], acc) do
+    acc =
+      case key in Appsignal.Config.request_headers() do
+        true -> Map.put(acc, "req_headers.#{key}", value)
+        false -> acc
+      end
+
+    headers(tail, acc)
+  end
+
+  defp headers(_, acc) do
+    acc
   end
 end

--- a/test/appsignal_plug/metadata_test.exs
+++ b/test/appsignal_plug/metadata_test.exs
@@ -1,0 +1,91 @@
+defmodule Appsignal.Plug.MetadataTest do
+  use ExUnit.Case
+
+  setup do
+    %{conn: %Plug.Conn{}}
+  end
+
+  test "extracts the conn's host", %{conn: conn} do
+    assert conn
+           |> Appsignal.Metadata.metadata()
+           |> Map.get("host") == "www.example.com"
+  end
+
+  test "extracts the conn's method", %{conn: conn} do
+    assert conn
+           |> Appsignal.Metadata.metadata()
+           |> Map.get("method") == "GET"
+  end
+
+  test "extracts the conn's request_path", %{conn: conn} do
+    assert conn
+           |> Appsignal.Metadata.metadata()
+           |> Map.get("request_path") == ""
+  end
+
+  test "extracts the conn's port", %{conn: conn} do
+    assert conn
+           |> Appsignal.Metadata.metadata()
+           |> Map.get("port") == 0
+  end
+
+  test "extracts the conn's status", %{conn: conn} do
+    assert conn
+           |> Appsignal.Metadata.metadata()
+           |> Map.get("status") == nil
+  end
+
+  test "extracts the conn's request_id", %{conn: conn} do
+    assert conn
+           |> Appsignal.Metadata.metadata()
+           |> Map.get("request_id") == nil
+  end
+
+  describe "when the conn's status is set" do
+    setup %{conn: conn} do
+      %{conn: %{conn | status: 200}}
+    end
+
+    test "extracts the conn's status", %{conn: conn} do
+      assert conn
+             |> Appsignal.Metadata.metadata()
+             |> Map.get("status") == 200
+    end
+  end
+
+  describe "when the conn's request_id is set" do
+    setup %{conn: conn} do
+      %{conn: Plug.Conn.put_resp_header(conn, "x-request-id", "request_id")}
+    end
+
+    test "extracts the conn's request_id", %{conn: conn} do
+      assert conn
+             |> Appsignal.Metadata.metadata()
+             |> Map.get("request_id") == "request_id"
+    end
+  end
+
+  describe "when the conn's request_headers are set" do
+    setup %{conn: conn} do
+      %{
+        conn:
+          conn
+          |> Plug.Conn.put_req_header("accept", "text/html")
+          |> Plug.Conn.put_req_header("foo", "bar")
+      }
+    end
+
+    test "extracts the conn's request headers", %{conn: conn} do
+      assert conn
+             |> Appsignal.Metadata.metadata()
+             |> Map.get("req_headers.accept") == "text/html"
+    end
+
+    test "does not extract request headers that are not listed in the request header configuration",
+         %{conn: conn} do
+      refute conn
+             |> Appsignal.Metadata.metadata()
+             |> Map.get("req_headers.foo")
+    end
+  end
+end

--- a/test/appsignal_plug/metadata_test.exs
+++ b/test/appsignal_plug/metadata_test.exs
@@ -88,4 +88,14 @@ defmodule Appsignal.Plug.MetadataTest do
              |> Map.get("req_headers.foo")
     end
   end
+
+  describe "when the conn's request_headers are nil" do
+    setup %{conn: conn} do
+      %{conn: %{conn | req_headers: nil}}
+    end
+
+    test "does not crash", %{conn: conn} do
+      assert Appsignal.Metadata.metadata(conn)
+    end
+  end
 end

--- a/test/appsignal_plug_test.exs
+++ b/test/appsignal_plug_test.exs
@@ -514,6 +514,12 @@ defmodule Appsignal.PlugTest do
     end
   end
 
+  test "handles requests with nil request headers" do
+    conn = %{conn(:get, "/", nil) | req_headers: nil}
+
+    assert PlugWithAppsignal.call(conn, [])
+  end
+
   defp get(path, params_or_body \\ nil) do
     conn =
       :get


### PR DESCRIPTION
As reported through support, where a user ran into issues having AppSignal installed while testing with a `Plug.Conn` struct that had `nil` set as its `request_headers` attribute.