### PR TITLE
Use Appsignal.Logger in Appsignal.Plug

### DIFF
--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -28,7 +28,7 @@ defmodule Appsignal.Plug do
   defmacro __using__(_) do
     quote do
       require Logger
-      Logger.debug("AppSignal.Plug attached to #{__MODULE__}")
+      Appsignal.Logger.debug("AppSignal.Plug attached to #{__MODULE__}")
 
       @tracer Application.get_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
       @span Application.get_env(:appsignal, :appsignal_span, Appsignal.Span)

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Appsignal.Plug.MixProject do
   defp deps do
     [
       {:plug, ">= 1.1.0"},
-      {:appsignal, ">= 2.0.6 and < 3.0.0"},
+      {:appsignal, ">= 2.1.5 and < 3.0.0"},
       {:credo, "~> 1.2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false}


### PR DESCRIPTION
Part of https://github.com/appsignal/appsignal-elixir/issues/634, this patch uses `Appsignal.Logger.debug/1` instead of `Logger.debug/1` to only send log lines to Elixir’s `Logger` when AppSignal’s `:debug` configuration is set to `true`.