### PR TITLE
Add Git linter to build

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -5,7 +5,20 @@ agent:
     type: e1-standard-2
     os_image: ubuntu1804
 blocks:
-  - name: Run linters
+  - name: Run other linters
+    dependencies: []
+    task:
+      env_vars:
+        - name: LINTJE_VERSION
+          value: "0.2.0"
+      jobs:
+        - name: Git Lint (Lintje)
+          commands:
+            - checkout
+            - script/install_lintje
+            - $HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE
+  - name: Run Elixir linters
+    dependencies: []
     task:
       prologue:
         commands:
@@ -34,6 +47,7 @@ blocks:
         - name: MIX_ENV
           value: test
   - name: Run tests
+    dependencies: []
     task:
       jobs:
         - name: Elixir master, OTP 23

--- a/script/install_lintje
+++ b/script/install_lintje
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+
+mkdir -p $HOME/bin
+cache_key=v1-lintje-$LINTJE_VERSION
+cache restore $cache_key
+
+# File exists and is executable
+if [ -x "$HOME/bin/lintje" ]; then
+  echo "Restored Lintje $LINTJE_VERSION from cache"
+else
+  echo "Downloading Lintje $LINTJE_VERSION"
+  curl -L \
+    https://github.com/tombruijn/lintje/releases/download/v$LINTJE_VERSION/x86_64-unknown-linux-gnu.tar.gz | \
+    tar -xz --directory $HOME/bin
+  cache store $cache_key $HOME/bin/lintje
+fi


### PR DESCRIPTION
Enforce a Git standard by adding a linter to the build.
Lintje can be found at: https://github.com/tombruijn/lintje/

Whenever a commit is found that doesn't match the Git standards enforced
by Lintje it will fail this job and in turn the build. Fix the issues
highlighted by Lintje and (force) push your changes (on feature/PR
branches. Don't force push base branches).
Lintje will check all pushed commits in a PR or pushed branch using the
`SEMAPHORE_GIT_COMMIT_RANGE` env variable.

Disclaimer: I am the author of Lintje. Lintje is a personal project.
This addition was discussed with Jeff before making this change.