### PR TITLE
Resolve mime dependency issue for Elixir 1.9

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,12 +31,24 @@ defmodule Appsignal.Plug.MixProject do
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do
+    system_version = System.version()
+
+    mime_dependency =
+      if Mix.env() == :test || Mix.env() == :test_no_nif do
+        case Version.compare(system_version, "1.10.0") do
+          :lt -> [{:mime, "~> 1.0"}]
+          _ -> []
+        end
+      else
+        []
+      end
+
     [
       {:plug, ">= 1.1.0"},
       {:appsignal, ">= 2.1.5 and < 3.0.0"},
       {:credo, "~> 1.2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false}
-    ]
+    ] ++ mime_dependency
   end
 end


### PR DESCRIPTION
[skip changeset]

Mime is depended on by plug in all environments. CI
breaks on Elixir 1.9.4 if it picks mime 2.0.x. This patch explicitly
locks to mime ~> 1.0 on Elixir versions before 1.10.