### PR TITLE
Update CI build versions

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -5,160 +5,93 @@ agent:
     type: e1-standard-2
     os_image: ubuntu1804
 blocks:
-  - name: Run other linters
-    dependencies: []
-    task:
-      env_vars:
-        - name: LINTJE_VERSION
-          value: "0.3.0"
-      jobs:
-        - name: Git Lint (Lintje)
-          commands:
-            - checkout
-            - script/install_lintje
-            - $HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE
-  - name: Run Elixir linters
-    dependencies: []
+  - name: Run linters and tests
     task:
       prologue:
         commands:
-          - sem-version erlang 23.2
-          - sem-version elixir master
-          - elixir -v
           - checkout
-          - mix local.rebar --force
-          - mix local.hex --force
-          - mix deps.get
-
       jobs:
+        - name: Git Lint (Lintje)
+          env_vars:
+            - name: LINTJE_VERSION
+              value: "0.3.0"
+          commands:
+            - script/install_lintje
+            - $HOME/bin/lintje $SEMAPHORE_GIT_COMMIT_RANGE
+        - name: mix compile --warnings-as-errors
+          commands:
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 bin/setup
+            - mix compile --warnings-as-errors
         - name: mix format --check-formatted
           commands:
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 bin/setup
             - mix format --check-formatted
         - name: mix credo --strict
           commands:
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 bin/setup
             - mix credo --strict
         - name: mix dialyzer
           commands:
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master bin/setup
             - cache restore dialyzer-plt
-            - mix dialyzer --plt
+            - MIX_ENV=test mix dialyzer --plt
             - cache store dialyzer-plt priv/plts/
-            - mix dialyzer
-      env_vars:
-        - name: MIX_ENV
-          value: test
-  - name: Run tests
-    dependencies: []
-    task:
-      jobs:
-        - name: Elixir master, OTP 23
+            - MIX_ENV=test mix dialyzer
+        - name: Elixir master, OTP 24
           commands:
-            - sem-version erlang 23.2
-            - sem-version elixir master
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master bin/setup
             - mix test
-        - name: Elixir master, OTP 22
+        - name: Elixir 1.12.2, OTP 24
           commands:
-            - sem-version erlang 22.3
-            - sem-version elixir master
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 bin/setup
             - mix test
-        - name: Elixir 1.11.3, OTP 23
+        - name: Elixir 1.12.2, OTP 23
           commands:
-            - sem-version erlang 23.2
-            - sem-version elixir 1.11.3
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.12.2 bin/setup
             - mix test
-        - name: Elixir 1.11.3, OTP 22
+        - name: Elixir 1.12.2, OTP 22
           commands:
-            - sem-version erlang 22.3
-            - sem-version elixir 1.11.3
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.12.2 bin/setup
             - mix test
-        - name: Elixir 1.11.3, OTP 21
+        - name: Elixir 1.11.4, OTP 24
           commands:
-            - sem-version erlang 21.3
-            - sem-version elixir 1.11.3
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.11.4 bin/setup
+            - mix test
+        - name: Elixir 1.11.4, OTP 23
+          commands:
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.11.4 bin/setup
+            - mix test
+        - name: Elixir 1.11.4, OTP 22
+          commands:
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.11.4 bin/setup
+            - mix test
+        - name: Elixir 1.11.4, OTP 21
+          commands:
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.11.4 bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 23
           commands:
-            - sem-version erlang 23.2
-            - sem-version elixir 1.10.4
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 22
           commands:
-            - sem-version erlang 22.3
-            - sem-version elixir 1.10.4
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.10.4 bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 21
           commands:
-            - sem-version erlang 21.3
-            - sem-version elixir 1.10.4
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.10.4 bin/setup
             - mix test
         - name: Elixir 1.9.4, OTP 22
           commands:
-            - sem-version erlang 22.3
-            - sem-version elixir 1.9.4
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.9.4 bin/setup
             - mix test
         - name: Elixir 1.9.4, OTP 21
           commands:
-            - sem-version erlang 21.3
-            - sem-version elixir 1.9.4
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.9.4 bin/setup
             - mix test
         - name: Elixir 1.9.4, OTP 20
           commands:
-            - sem-version erlang 20.3
-            - sem-version elixir 1.9.4
-            - elixir -v
-            - checkout
-            - mix local.rebar --force
-            - mix local.hex --force
-            - mix deps.get
+            - ERLANG_VERSION=20.3 ELIXIR_VERSION=1.9.4 bin/setup
             - mix test
       env_vars:
         - name: MIX_ENV

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,12 @@
+if [[ $ELIXIR_VERSION == "master" ]]; then
+  kiex install $ELIXIR_VERSION
+fi
+
+sem-version erlang $ERLANG_VERSION
+erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell
+sem-version elixir $ELIXIR_VERSION
+elixir -v
+checkout
+mix local.rebar --force
+mix local.hex --force
+mix deps.get


### PR DESCRIPTION
[skip changeset]

CI was running with older versions of OTP and Elixir. Updated it to work
as the Elixir library.

Old Elixir versions are broken because of the Mime issue. It's addressed here -> https://github.com/appsignal/appsignal-elixir-plug/pull/17

We should merge this one before the Mime issue fix.