### PR TITLE
Replace uses of `set_sample_data`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Appsignal.Plug.MixProject do
 
     [
       {:plug, ">= 1.1.0"},
-      {:appsignal, ">= 2.1.5 and < 3.0.0"},
+      {:appsignal, ">= 2.2.8 and < 3.0.0"},
       {:credo, "~> 1.2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false}

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,11 @@ defmodule Appsignal.Plug.MixProject do
 
     [
       {:plug, ">= 1.1.0"},
-      {:appsignal, ">= 2.2.8 and < 3.0.0"},
+      {
+        :appsignal,
+        ">= 2.2.7 and < 3.0.0",
+        github: "appsignal/appsignal-elixir", branch: "deprecate-set-sample-data"
+      },
       {:credo, "~> 1.2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false}


### PR DESCRIPTION
[skip changeset]

Do not merge before appsignal/appsignal-elixir#713.

### Replace uses of set_sample_data

Since `set_sample_data/3` is deprecated, usages of it have been replaced with `set_params/2`, `set_environment/2` and `set_session_data/2`.

### Point to the integration's branch 

TODO:
- [ ] Rebase out this commit before merging, after the `deprecate-set-sample-data` branch has been merged to `main`.
