### PR TITLE
Fix Erlang/OTP and Elixir version in CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -16,78 +16,78 @@ blocks:
             - script/lint_git
         - name: mix compile --warnings-as-errors
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
             - mix compile --warnings-as-errors
         - name: mix format --check-formatted
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
             - mix format --check-formatted
         - name: mix credo --strict
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
             - mix credo --strict
         - name: mix dialyzer
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=main . bin/setup
             - cache restore dialyzer-plt
             - MIX_ENV=test mix dialyzer --plt
             - cache store dialyzer-plt priv/plts/
             - MIX_ENV=test mix dialyzer
-        - name: Elixir master, OTP 24
+        - name: Elixir main, OTP 24
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=master bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=main . bin/setup
             - mix test
         - name: Elixir 1.12.2, OTP 24
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
             - mix test
         - name: Elixir 1.12.2, OTP 23
           commands:
-            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.12.2 bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.12.2 . bin/setup
             - mix test
         - name: Elixir 1.12.2, OTP 22
           commands:
-            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.12.2 bin/setup
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.12.2 . bin/setup
             - mix test
         - name: Elixir 1.11.4, OTP 24
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.11.4 bin/setup
+            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.11.4 . bin/setup
             - mix test
         - name: Elixir 1.11.4, OTP 23
           commands:
-            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.11.4 bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.11.4 . bin/setup
             - mix test
         - name: Elixir 1.11.4, OTP 22
           commands:
-            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.11.4 bin/setup
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.11.4 . bin/setup
             - mix test
         - name: Elixir 1.11.4, OTP 21
           commands:
-            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.11.4 bin/setup
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.11.4 . bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 23
           commands:
-            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 bin/setup
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 22
           commands:
-            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.10.4 bin/setup
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix test
         - name: Elixir 1.10.4, OTP 21
           commands:
-            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.10.4 bin/setup
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix test
         - name: Elixir 1.9.4, OTP 22
           commands:
-            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.9.4 bin/setup
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.9.4 . bin/setup
             - mix test
         - name: Elixir 1.9.4, OTP 21
           commands:
-            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.9.4 bin/setup
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.9.4 . bin/setup
             - mix test
         - name: Elixir 1.9.4, OTP 20
           commands:
-            - ERLANG_VERSION=20.3 ELIXIR_VERSION=1.9.4 bin/setup
+            - ERLANG_VERSION=20.3 ELIXIR_VERSION=1.9.4 . bin/setup
             - mix test
       env_vars:
         - name: MIX_ENV

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -85,10 +85,6 @@ blocks:
           commands:
             - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.9.4 . bin/setup
             - mix test
-        - name: Elixir 1.9.4, OTP 20
-          commands:
-            - ERLANG_VERSION=20.3 ELIXIR_VERSION=1.9.4 . bin/setup
-            - mix test
       env_vars:
         - name: MIX_ENV
           value: test

--- a/bin/setup
+++ b/bin/setup
@@ -1,12 +1,34 @@
-if [[ $ELIXIR_VERSION == "master" ]]; then
-  kiex install $ELIXIR_VERSION
-fi
+#!/bin/bash
+
+set -e
+
+elixirs_key="elixir-$ELIXIR_VERSION-erlang-$ERLANG_VERSION-elixirs"
+archives_key="elixir-$ELIXIR_VERSION-erlang-$ERLANG_VERSION-archives"
+
+elixirs_path=~/".kiex/elixirs"
+archives_path=~/".kiex/mix/archives"
+
+rm -rf "$elixirs_path"/*
+rm -rf "$archives_path"/*
 
 sem-version erlang $ERLANG_VERSION
 erl -eval '{ok, Version} = file:read_file(filename:join([code:root_dir(), "releases", erlang:system_info(otp_release), "OTP_VERSION"])), io:fwrite(Version), halt().' -noshell
-sem-version elixir $ELIXIR_VERSION
+
+if [ $ELIXIR_VERSION != "main" ] && \
+   cache has_key "$elixirs_key" && \
+   cache has_key "$archives_key"
+then
+  cache restore "$elixirs_key"
+  cache restore "$archives_key"
+else
+  kiex install $ELIXIR_VERSION
+  cache store "$elixirs_key" "$elixirs_path"
+  cache store "$archives_key" "$archives_path"
+fi
+
+kiex use $ELIXIR_VERSION
 elixir -v
-checkout
+
 mix local.rebar --force
 mix local.hex --force
 mix deps.get


### PR DESCRIPTION
[skip changeset]

### Source `bin/setup` instead of running it

The Semaphore-provided utilities, such as `sem-version`, are provided as shell functions. To use them from a script, the script must be sourced, not invoked. As such, before this commit, calls to `sem-version` within the `bin/setup` script were failing, and all the test runs were using the versions of Elixir and Erlang provided by Semaphore by default.

This commit also renames the Elixir `master` version to `main`, which was not failing before for the same reason.

### Fix Erlang/OTP version usage in CI

This commit reproduces the changes in [appsignal-elixir#718][pr] for the Plug repository, making it so that the intended Erlang and Elixir versions are used, by selecting the Erlang version before the Elixir one, compiling the desired Elixir version against the selected Erlang version, caching the compiled Elixir version, and removing OTP 20 checks from CI.

[pr]: appsignal/appsignal-elixir#718