### PR TITLE
Switch skip_session_data to send_session_data

### DIFF
--- a/.changesets/use-send_session_data-instead-of-skip_session_data.md
+++ b/.changesets/use-send_session_data-instead-of-skip_session_data.md
@@ -1,0 +1,8 @@
+---
+bump: "patch"
+type: "change"
+---
+
+Update the plug integration to listen to the `send_session_data` config option instead of
+`skip_session_data`. The `send_session_data` config option is backwards compatible with
+the `skip_session_data` config option.

--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -184,7 +184,7 @@ defmodule Appsignal.Plug do
     set_session_data(span, Application.get_env(:appsignal, :config), conn)
   end
 
-  defp set_session_data(span, %{skip_session_data: false}, %Plug.Conn{
+  defp set_session_data(span, %{send_session_data: true}, %Plug.Conn{
          private: %{plug_session: session, plug_session_fetch: :done}
        }) do
     @span.set_sample_data(span, "session_data", session)

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Appsignal.Plug.MixProject do
 
     [
       {:plug, ">= 1.1.0"},
-      {:appsignal, ">= 2.1.5 and < 3.0.0"},
+      {:appsignal, ">= 2.2.10 and < 3.0.0"},
       {:credo, "~> 1.2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false}

--- a/test/appsignal_plug_test.exs
+++ b/test/appsignal_plug_test.exs
@@ -493,9 +493,9 @@ defmodule Appsignal.PlugTest do
       refute sample_data("session_data", %{key: "value"})
     end
 
-    test "does not set session data when skip_session_data is set to true", %{span: span} do
+    test "does not set session data when send_session_data is set to false", %{span: span} do
       config = Application.get_env(:appsignal, :config)
-      Application.put_env(:appsignal, :config, %{config | skip_session_data: true})
+      Application.put_env(:appsignal, :config, %{config | send_session_data: false})
 
       try do
         Appsignal.Plug.set_conn_data(span, %Plug.Conn{


### PR DESCRIPTION
The usage of the `skip_session_data` config option is now switched to
`send_session_data`. The `appsignal-elixir` dependency is now locked to
start from version `2.2.10` as it's the first one that sends the
`send_session_data` config opt instead of `skip_session_data`.