### PR TITLE
Param and session filtering

### DIFF
--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -166,33 +166,21 @@ defmodule Appsignal.Plug do
   end
 
   defp set_params(span, conn) do
-    set_params(span, Application.get_env(:appsignal, :config), conn)
-  end
-
-  defp set_params(span, %{send_params: true}, conn) do
     %Plug.Conn{params: params} = Plug.Conn.fetch_query_params(conn)
     @span.set_sample_data(span, "params", params)
-  end
-
-  defp set_params(span, _config, _conn) do
-    span
   end
 
   defp set_sample_data(span, conn) do
     @span.set_sample_data(span, "environment", Appsignal.Metadata.metadata(conn))
   end
 
-  defp set_session_data(span, conn) do
-    set_session_data(span, Application.get_env(:appsignal, :config), conn)
-  end
-
-  defp set_session_data(span, %{send_session_data: true}, %Plug.Conn{
+  defp set_session_data(span, %Plug.Conn{
          private: %{plug_session: session, plug_session_fetch: :done}
        }) do
     @span.set_sample_data(span, "session_data", session)
   end
 
-  defp set_session_data(span, _config, _conn) do
+  defp set_session_data(span, _conn) do
     span
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule Appsignal.Plug.MixProject do
 
     [
       {:plug, ">= 1.1.0"},
-      {:appsignal, ">= 2.2.10 and < 3.0.0"},
+      {:appsignal, ">= 2.2.13 and < 3.0.0"},
       {:credo, "~> 1.2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false}

--- a/test/appsignal_plug_test.exs
+++ b/test/appsignal_plug_test.exs
@@ -459,7 +459,7 @@ defmodule Appsignal.PlugTest do
       assert Appsignal.Plug.set_conn_data(span, %Plug.Conn{method: "GET", params: %{"id" => "4"}}) ==
                span
 
-      assert sample_data("params", %{"id" => "4"})
+      assert %{"sample_data" => %{"params" => ~s({"id":"4"})}} = Appsignal.Span.to_map(span)
     end
 
     test "does not set params when send_params is set to false", %{span: span} do
@@ -472,7 +472,8 @@ defmodule Appsignal.PlugTest do
         Application.put_env(:appsignal, :config, config)
       end
 
-      refute sample_data("params", %{"id" => "4"})
+      %{"sample_data" => sample_data} = Appsignal.Span.to_map(span)
+      refute Map.has_key?(sample_data, "params")
     end
 
     test "sets the span's session data", %{span: span} do
@@ -485,12 +486,15 @@ defmodule Appsignal.PlugTest do
                }
              }) == span
 
-      assert sample_data("session_data", %{key: "value"})
+      %{"sample_data" => sample_data} = Appsignal.Span.to_map(span)
+      assert ~s({"key":"value"}) == sample_data["session_data"]
     end
 
     test "does not set unfetched session data", %{span: span} do
       assert Appsignal.Plug.set_conn_data(span, %Plug.Conn{}) == span
-      refute sample_data("session_data", %{key: "value"})
+
+      %{"sample_data" => sample_data} = Appsignal.Span.to_map(span)
+      refute Map.has_key?(sample_data, "session_data")
     end
 
     test "does not set session data when send_session_data is set to false", %{span: span} do
@@ -510,7 +514,8 @@ defmodule Appsignal.PlugTest do
         Application.put_env(:appsignal, :config, config)
       end
 
-      refute sample_data("session_data", %{key: "value"})
+      %{"sample_data" => sample_data} = Appsignal.Span.to_map(span)
+      refute Map.has_key?(sample_data, "session_data")
     end
   end
 


### PR DESCRIPTION
Since appsignal 2.2.13 (which includes https://github.com/appsignal/appsignal-elixir/pull/771 and https://github.com/appsignal/appsignal-elixir/pull/772), the app’s configuration is checked whenever parameters or session data is added to the current span.

This patch updates the appsignal version dependency to 2.2.13 or higher, and removes the duplicate checks from Appsignal.Plug.

This patch also adds tests to make sure the parameter and session filtering keeps working like before, by checking the reported data in the Appsignal.Plug tests.