### PR TITLE
Update Elixir and OTP versions in CI matrix

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,3 +1,7 @@
+# DO NOT EDIT
+# This is a generated file by the `script/generate_ci_matrix` task.
+# See `.semaphore/semaphore.yml.erb` for the build matrix.
+# Generate this file with `script/generate_ci_matrix`.
 version: v1.0
 name: AppSignal Elixir Build and Tests
 agent:
@@ -14,76 +18,115 @@ blocks:
         - name: Git Lint (Lintje)
           commands:
             - script/lint_git
+        - name: Validate CI matrix
+          commands:
+            - script/validate_ci_matrix
         - name: mix compile --warnings-as-errors
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
+            - ERLANG_VERSION=25.0 ELIXIR_VERSION=1.14.0 . bin/setup
             - mix compile --warnings-as-errors
         - name: mix format --check-formatted
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
+            - ERLANG_VERSION=25.0 ELIXIR_VERSION=1.14.0 . bin/setup
             - mix format --check-formatted
         - name: mix credo --strict
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
+            - ERLANG_VERSION=25.0 ELIXIR_VERSION=1.14.0 . bin/setup
             - mix credo --strict
         - name: mix dialyzer
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=main . bin/setup
+            - ERLANG_VERSION=25.0 ELIXIR_VERSION=1.14.0 . bin/setup
             - cache restore dialyzer-plt
             - MIX_ENV=test mix dialyzer --plt
             - cache store dialyzer-plt priv/plts/
             - MIX_ENV=test mix dialyzer
-        - name: Elixir main, OTP 24
+        - name: Elixir main, OTP 25.0
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=main . bin/setup
+            - ERLANG_VERSION=25.0 ELIXIR_VERSION=main . bin/setup
             - mix test
-        - name: Elixir 1.12.2, OTP 24
+        - name: Elixir 1.14.0, OTP 25.0
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.12.2 . bin/setup
+            - ERLANG_VERSION=25.0 ELIXIR_VERSION=1.14.0 . bin/setup
             - mix test
-        - name: Elixir 1.12.2, OTP 23
+        - name: Elixir 1.13.4, OTP 25.0
           commands:
-            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.12.2 . bin/setup
+            - ERLANG_VERSION=25.0 ELIXIR_VERSION=1.13.4 . bin/setup
             - mix test
-        - name: Elixir 1.12.2, OTP 22
+        - name: Elixir main, OTP 24.3
           commands:
-            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.12.2 . bin/setup
+            - ERLANG_VERSION=24.3 ELIXIR_VERSION=main . bin/setup
             - mix test
-        - name: Elixir 1.11.4, OTP 24
+        - name: Elixir 1.14.0, OTP 24.3
           commands:
-            - ERLANG_VERSION=24.0 ELIXIR_VERSION=1.11.4 . bin/setup
+            - ERLANG_VERSION=24.3 ELIXIR_VERSION=1.14.0 . bin/setup
             - mix test
-        - name: Elixir 1.11.4, OTP 23
+        - name: Elixir 1.13.3, OTP 24.3
+          commands:
+            - ERLANG_VERSION=24.3 ELIXIR_VERSION=1.13.3 . bin/setup
+            - mix test
+        - name: Elixir 1.12.3, OTP 24.3
+          commands:
+            - ERLANG_VERSION=24.3 ELIXIR_VERSION=1.12.3 . bin/setup
+            - mix test
+        - name: Elixir 1.11.4, OTP 24.3
+          commands:
+            - ERLANG_VERSION=24.3 ELIXIR_VERSION=1.11.4 . bin/setup
+            - mix test
+        - name: Elixir 1.14.0, OTP 23.3
+          commands:
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.14.0 . bin/setup
+            - mix test
+        - name: Elixir 1.13.3, OTP 23.3
+          commands:
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.13.3 . bin/setup
+            - mix test
+        - name: Elixir 1.12.3, OTP 23.3
+          commands:
+            - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.12.3 . bin/setup
+            - mix test
+        - name: Elixir 1.11.4, OTP 23.3
           commands:
             - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.11.4 . bin/setup
             - mix test
-        - name: Elixir 1.11.4, OTP 22
-          commands:
-            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.11.4 . bin/setup
-            - mix test
-        - name: Elixir 1.11.4, OTP 21
-          commands:
-            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.11.4 . bin/setup
-            - mix test
-        - name: Elixir 1.10.4, OTP 23
+        - name: Elixir 1.10.4, OTP 23.3
           commands:
             - ERLANG_VERSION=23.3 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix test
-        - name: Elixir 1.10.4, OTP 22
+        - name: Elixir 1.13.3, OTP 22.3
+          commands:
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.13.3 . bin/setup
+            - mix test
+        - name: Elixir 1.12.3, OTP 22.3
+          commands:
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.12.3 . bin/setup
+            - mix test
+        - name: Elixir 1.11.4, OTP 22.3
+          commands:
+            - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.11.4 . bin/setup
+            - mix test
+        - name: Elixir 1.10.4, OTP 22.3
           commands:
             - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.10.4 . bin/setup
             - mix test
-        - name: Elixir 1.10.4, OTP 21
-          commands:
-            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.10.4 . bin/setup
-            - mix test
-        - name: Elixir 1.9.4, OTP 22
+        - name: Elixir 1.9.4, OTP 22.3
           commands:
             - ERLANG_VERSION=22.3 ELIXIR_VERSION=1.9.4 . bin/setup
             - mix test
-        - name: Elixir 1.9.4, OTP 21
+        - name: Elixir 1.11.4, OTP 21.3
+          commands:
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.11.4 . bin/setup
+            - mix test
+        - name: Elixir 1.10.4, OTP 21.3
+          commands:
+            - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.10.4 . bin/setup
+            - mix test
+        - name: Elixir 1.9.4, OTP 21.3
           commands:
             - ERLANG_VERSION=21.3 ELIXIR_VERSION=1.9.4 . bin/setup
+            - mix test
+        - name: Elixir 1.9.4, OTP 20.3
+          commands:
+            - ERLANG_VERSION=20.3 ELIXIR_VERSION=1.9.4 . bin/setup
             - mix test
       env_vars:
         - name: MIX_ENV

--- a/.semaphore/semaphore.yml.erb
+++ b/.semaphore/semaphore.yml.erb
@@ -1,0 +1,58 @@
+<%
+require_relative "versions"
+NEWEST_OTP = VERSIONS.keys.first
+NEWEST_ELIXIR = VERSIONS[NEWEST_OTP][1]
+-%>
+# DO NOT EDIT
+# This is a generated file by the `script/generate_ci_matrix` task.
+# See `.semaphore/semaphore.yml.erb` for the build matrix.
+# Generate this file with `script/generate_ci_matrix`.
+version: v1.0
+name: AppSignal Elixir Build and Tests
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Run linters and tests
+    task:
+      prologue:
+        commands:
+          - checkout
+      jobs:
+        - name: Git Lint (Lintje)
+          commands:
+            - script/lint_git
+        - name: Validate CI matrix
+          commands:
+            - script/validate_ci_matrix
+        - name: mix compile --warnings-as-errors
+          commands:
+            - ERLANG_VERSION=<%= NEWEST_OTP %> ELIXIR_VERSION=<%= NEWEST_ELIXIR %> . bin/setup
+            - mix compile --warnings-as-errors
+        - name: mix format --check-formatted
+          commands:
+            - ERLANG_VERSION=<%= NEWEST_OTP %> ELIXIR_VERSION=<%= NEWEST_ELIXIR %> . bin/setup
+            - mix format --check-formatted
+        - name: mix credo --strict
+          commands:
+            - ERLANG_VERSION=<%= NEWEST_OTP %> ELIXIR_VERSION=<%= NEWEST_ELIXIR %> . bin/setup
+            - mix credo --strict
+        - name: mix dialyzer
+          commands:
+            - ERLANG_VERSION=<%= NEWEST_OTP %> ELIXIR_VERSION=<%= NEWEST_ELIXIR %> . bin/setup
+            - cache restore dialyzer-plt
+            - MIX_ENV=test mix dialyzer --plt
+            - cache store dialyzer-plt priv/plts/
+            - MIX_ENV=test mix dialyzer
+<% VERSIONS.each do |otp_version, elixir_versions| -%>
+<% elixir_versions.each do |elixir_version| -%>
+        - name: Elixir <%= elixir_version %>, OTP <%= otp_version %>
+          commands:
+            - ERLANG_VERSION=<%= otp_version %> ELIXIR_VERSION=<%= elixir_version %> . bin/setup
+            - mix test
+<% end -%>
+<% end -%>
+      env_vars:
+        - name: MIX_ENV
+          value: test

--- a/.semaphore/versions.rb
+++ b/.semaphore/versions.rb
@@ -1,0 +1,12 @@
+# DO NOT EDIT
+# This is a file downloaded by the `script/generate_ci_matrix` task.
+# Update it in appsignal-elixir, then run script/generate_ci_matrix to
+# redownload it.
+VERSIONS = {
+  "25.0" => ["main", "1.14.0", "1.13.4"],
+  "24.3" => ["main", "1.14.0", "1.13.3", "1.12.3", "1.11.4"],
+  "23.3" => ["1.14.0", "1.13.3", "1.12.3", "1.11.4", "1.10.4"],
+  "22.3" => ["1.13.3", "1.12.3", "1.11.4", "1.10.4", "1.9.4"],
+  "21.3" => ["1.11.4", "1.10.4", "1.9.4"],
+  "20.3" => ["1.9.4"]
+}

--- a/mix.exs
+++ b/mix.exs
@@ -32,6 +32,7 @@ defmodule Appsignal.Plug.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     system_version = System.version()
+    otp_version = System.otp_release()
 
     mime_dependency =
       if Mix.env() == :test || Mix.env() == :test_no_nif do
@@ -43,12 +44,19 @@ defmodule Appsignal.Plug.MixProject do
         []
       end
 
+    telemetry_version =
+      case otp_version < "21" do
+        true -> "~> 0.4"
+        false -> "~> 0.4 or ~> 1.0"
+      end
+
     [
       {:plug, ">= 1.1.0"},
       {:appsignal, ">= 2.2.13 and < 3.0.0"},
       {:credo, "~> 1.2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
-      {:ex_doc, "~> 0.21", only: :dev, runtime: false}
+      {:ex_doc, "~> 0.21", only: :dev, runtime: false},
+      {:telemetry, telemetry_version}
     ] ++ mime_dependency
   end
 end

--- a/script/generate_ci_matrix
+++ b/script/generate_ci_matrix
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -eu
+
+echo "# DO NOT EDIT
+# This is a file downloaded by the \`script/generate_ci_matrix\` task.
+# Update it in appsignal-elixir, then run script/generate_ci_matrix to
+# redownload it." > .semaphore/versions.rb
+curl https://raw.githubusercontent.com/appsignal/appsignal-elixir/main/.semaphore/versions.rb >> .semaphore/versions.rb
+
+erb -T- .semaphore/semaphore.yml.erb > .semaphore/semaphore.yml	

--- a/script/validate_ci_matrix
+++ b/script/validate_ci_matrix
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eu
+
+if ! git diff --exit-code .semaphore/semaphore.yml; then
+  echo
+  echo "Error: There's a mismatch between the semaphore.yml and semaphore.yml.erb file."
+  exit 1
+fi


### PR DESCRIPTION
Instead of periodically updating the CI matrix file manually, this patch
adds a script to download the versions.rb file from the main
appsignal-elixir repository, then generate a CI matrix file from that.

That way, this repository's CI matrix always matches the main one,
without any work having to be done to keep them in sync.

This also includes a fix to make sure an older version of :telemetry is
used on the still-supported OTP 20, which is EOL but supported until
:appsignal_elixir 3.0 (as per 
https://github.com/appsignal/integration-guide/blob/7cf3b14f89c6cf8d84048ae54a5e739974410b02/maintain/version-support.md#programming-languages)

[skip changeset]