### PR TITLE
Use renamed Appsignal.IntegrationLogger

### DIFF
--- a/.changesets/fix-appsignal-logger-error-on-appsignal-for-elixir-1-4-0.md
+++ b/.changesets/fix-appsignal-logger-error-on-appsignal-for-elixir-1-4-0.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix Appsignal.Logger error on AppSignal for Elixir 1.4.0

--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -30,7 +30,7 @@ defmodule Appsignal.Plug do
     quote do
       require Logger
       require Appsignal.Utils
-      Appsignal.Logger.debug("AppSignal.Plug attached to #{__MODULE__}")
+      Appsignal.IntegrationLogger.debug("AppSignal.Plug attached to #{__MODULE__}")
 
       @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
       @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)

--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule Appsignal.Plug.MixProject do
 
     [
       {:plug, ">= 1.1.0"},
-      {:appsignal, ">= 2.2.13 and < 3.0.0"},
+      {:appsignal, ">= 2.4.0 and < 3.0.0"},
       {:credo, "~> 1.2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},


### PR DESCRIPTION
Appsignal.Logger was renamed to Appsignal.IntegrationLogger in :appsignal 2.4.0. This patch switches to using
Appsignal.IntegrationLogger and depends on :appsignal 2.4.0 or above.