### PR TITLE
Add fallback name for span

### DIFF
--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -46,7 +46,7 @@ defmodule Appsignal.Plug do
       end
 
       def call(conn, opts) do
-        Appsignal.instrument(fn span ->
+        Appsignal.instrument("[unknown request]", fn span ->
           _ = @span.set_namespace(span, "http_request")
 
           try do

--- a/test/appsignal_plug_test.exs
+++ b/test/appsignal_plug_test.exs
@@ -122,11 +122,12 @@ defmodule Appsignal.PlugTest do
     end
 
     test "sets the span's name" do
-      assert {:ok, [{%Span{}, "GET /"}]} = Test.Span.get(:set_name)
+      assert {:ok, [{%Span{}, "GET /"} | _]} = Test.Span.get(:set_name)
     end
 
     test "sets the span's category" do
-      assert {:ok, [{%Span{}, "appsignal:category", "call.plug"}]} = Test.Span.get(:set_attribute)
+      assert {:ok, [{%Span{}, "appsignal:category", "call.plug"} | _]} =
+               Test.Span.get(:set_attribute)
     end
 
     test "sets the span's sample data" do
@@ -156,7 +157,7 @@ defmodule Appsignal.PlugTest do
     end
 
     test "sets the span's name" do
-      assert {:ok, [{%Span{}, "GET /users/:id"}]} = Test.Span.get(:set_name)
+      assert {:ok, [{%Span{}, "GET /users/:id"} | _]} = Test.Span.get(:set_name)
     end
   end
 
@@ -232,7 +233,7 @@ defmodule Appsignal.PlugTest do
     end
 
     test "sets the span's name" do
-      assert {:ok, [{%Span{}, "GET /exception"}]} = Test.Span.get(:set_name)
+      assert {:ok, [{%Span{}, "GET /exception"} | _]} = Test.Span.get(:set_name)
     end
 
     test "sets the span's parameters" do
@@ -338,7 +339,7 @@ defmodule Appsignal.PlugTest do
     end
 
     test "adds the name to a nil-span" do
-      assert {:ok, [{nil, "GET /exception"}]} = Test.Span.get(:set_name)
+      assert {:ok, [{nil, "GET /exception"} | _]} = Test.Span.get(:set_name)
     end
 
     test "reraises the error", %{kind: kind, reason: reason} do
@@ -380,7 +381,7 @@ defmodule Appsignal.PlugTest do
     end
 
     test "does not overwrite the custom name" do
-      assert {:ok, [{%Span{}, "PlugWithAppsignal#custom_name"}]} = Test.Span.get(:set_name)
+      assert {:ok, [{%Span{}, "PlugWithAppsignal#custom_name"} | _]} = Test.Span.get(:set_name)
     end
   end
 
@@ -390,7 +391,7 @@ defmodule Appsignal.PlugTest do
     end
 
     test "extracts the controller and action name" do
-      assert {:ok, [{%Span{}, "PlugWithAppsignal#phoenix_action"}]} = Test.Span.get(:set_name)
+      assert {:ok, [{%Span{}, "PlugWithAppsignal#phoenix_action"} | _]} = Test.Span.get(:set_name)
     end
   end
 
@@ -428,7 +429,7 @@ defmodule Appsignal.PlugTest do
                private: %{plug_route: {"/", fn -> :ok end}}
              }) == span
 
-      assert {:ok, [{^span, "GET /"}]} = Test.Span.get(:set_name)
+      assert {:ok, [{^span, "GET /"} | _]} = Test.Span.get(:set_name)
     end
 
     test "sets the span's category", %{span: span} do


### PR DESCRIPTION
If a root span does not have a name, the whole trace will be thrown out. Give the root span a fallback name that is meant to be overridden in order to prevent this.

Fixes appsignal/support#217, in the sense that it will enable us to debug this better if/when it happens again (we'll be able to have a conversation about ugly span names, instead of one about no data showing up at all)