### PR TITLE
Expose metadata functions for use in Phoenix integration

### DIFF
--- a/.changesets/add-metadata-functions-for-plug-phoenix-apps.md
+++ b/.changesets/add-metadata-functions-for-plug-phoenix-apps.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "add"
+---
+
+Add metadata functions for Plug/Phoenix apps

--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -155,13 +155,7 @@ defmodule Appsignal.Plug do
     @span.set_sample_data(span, "environment", Appsignal.Metadata.metadata(conn))
   end
 
-  defp set_session_data(span, %Plug.Conn{
-         private: %{plug_session: session, plug_session_fetch: :done}
-       }) do
-    @span.set_sample_data(span, "session_data", session)
-  end
-
-  defp set_session_data(span, _conn) do
-    span
+  defp set_session_data(span, conn) do
+    @span.set_sample_data(span, "session_data", Appsignal.Metadata.session(conn))
   end
 end

--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -139,22 +139,8 @@ defmodule Appsignal.Plug do
     |> set_conn_data(conn_with_status)
   end
 
-  defp set_name(span, %Plug.Conn{private: %{appsignal_name: name}}) do
-    @span.set_name(span, name)
-  end
-
-  defp set_name(span, %Plug.Conn{
-         private: %{phoenix_action: action, phoenix_controller: controller}
-       }) do
-    @span.set_name(span, "#{module_name(controller)}##{action}")
-  end
-
-  defp set_name(span, %Plug.Conn{method: method, private: %{plug_route: {path, _fun}}}) do
-    @span.set_name(span, "#{method} #{path}")
-  end
-
-  defp set_name(span, _conn) do
-    span
+  defp set_name(span, conn) do
+    @span.set_name(span, Appsignal.Metadata.name(conn))
   end
 
   defp set_category(span, %Plug.Conn{private: %{phoenix_endpoint: _endpoint}}) do

--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -143,12 +143,8 @@ defmodule Appsignal.Plug do
     @span.set_name(span, Appsignal.Metadata.name(conn))
   end
 
-  defp set_category(span, %Plug.Conn{private: %{phoenix_endpoint: _endpoint}}) do
-    @span.set_attribute(span, "appsignal:category", "call.phoenix")
-  end
-
-  defp set_category(span, _conn) do
-    @span.set_attribute(span, "appsignal:category", "call.plug")
+  defp set_category(span, conn) do
+    @span.set_attribute(span, "appsignal:category", Appsignal.Metadata.category(conn))
   end
 
   defp set_params(span, conn) do

--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -1,7 +1,6 @@
 defmodule Appsignal.Plug do
   require Appsignal.Utils
   @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
-  import Appsignal.Utils, only: [module_name: 1]
 
   @moduledoc """
   AppSignal's Plug instrumentation instruments calls to Plug applications to
@@ -107,11 +106,11 @@ defmodule Appsignal.Plug do
   @doc false
   def set_conn_data(span, conn) do
     span
-    |> set_name(conn)
-    |> set_category(conn)
-    |> set_params(conn)
-    |> set_sample_data(conn)
-    |> set_session_data(conn)
+    |> @span.set_name(Appsignal.Metadata.name(conn))
+    |> @span.set_attribute("appsignal:category", Appsignal.Metadata.category(conn))
+    |> @span.set_sample_data("params", Appsignal.Metadata.params(conn))
+    |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(conn))
+    |> @span.set_sample_data("session_data", Appsignal.Metadata.session(conn))
   end
 
   @doc false
@@ -137,25 +136,5 @@ defmodule Appsignal.Plug do
     span
     |> @span.add_error(kind, reason, stack)
     |> set_conn_data(conn_with_status)
-  end
-
-  defp set_name(span, conn) do
-    @span.set_name(span, Appsignal.Metadata.name(conn))
-  end
-
-  defp set_category(span, conn) do
-    @span.set_attribute(span, "appsignal:category", Appsignal.Metadata.category(conn))
-  end
-
-  defp set_params(span, conn) do
-    @span.set_sample_data(span, "params", Appsignal.Metadata.params(conn))
-  end
-
-  defp set_sample_data(span, conn) do
-    @span.set_sample_data(span, "environment", Appsignal.Metadata.metadata(conn))
-  end
-
-  defp set_session_data(span, conn) do
-    @span.set_sample_data(span, "session_data", Appsignal.Metadata.session(conn))
   end
 end

--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -148,8 +148,7 @@ defmodule Appsignal.Plug do
   end
 
   defp set_params(span, conn) do
-    %Plug.Conn{params: params} = Plug.Conn.fetch_query_params(conn)
-    @span.set_sample_data(span, "params", params)
+    @span.set_sample_data(span, "params", Appsignal.Metadata.params(conn))
   end
 
   defp set_sample_data(span, conn) do

--- a/lib/appsignal_plug/metadata.ex
+++ b/lib/appsignal_plug/metadata.ex
@@ -51,6 +51,11 @@ defimpl Appsignal.Metadata, for: Plug.Conn do
     "call.plug"
   end
 
+  def params(conn) do
+    %Plug.Conn{params: params} = Plug.Conn.fetch_query_params(conn)
+    params
+  end
+
   defp headers(req_headers) do
     headers(req_headers, %{})
   end

--- a/lib/appsignal_plug/metadata.ex
+++ b/lib/appsignal_plug/metadata.ex
@@ -56,6 +56,14 @@ defimpl Appsignal.Metadata, for: Plug.Conn do
     params
   end
 
+  def session(%Plug.Conn{private: %{plug_session: session}}) do
+    session
+  end
+
+  def session(_conn) do
+    %{}
+  end
+
   defp headers(req_headers) do
     headers(req_headers, %{})
   end

--- a/lib/appsignal_plug/metadata.ex
+++ b/lib/appsignal_plug/metadata.ex
@@ -43,6 +43,14 @@ defimpl Appsignal.Metadata, for: Plug.Conn do
     nil
   end
 
+  def category(%Plug.Conn{private: %{phoenix_endpoint: _}}) do
+    "call.phoenix"
+  end
+
+  def category(_conn) do
+    "call.plug"
+  end
+
   defp headers(req_headers) do
     headers(req_headers, %{})
   end

--- a/lib/appsignal_plug/metadata.ex
+++ b/lib/appsignal_plug/metadata.ex
@@ -27,6 +27,22 @@ defimpl Appsignal.Metadata, for: Plug.Conn do
     )
   end
 
+  def name(%Plug.Conn{private: %{appsignal_name: appsignal_name}}) do
+    appsignal_name
+  end
+
+  def name(%Plug.Conn{private: %{phoenix_action: action, phoenix_controller: controller}}) do
+    "#{Appsignal.Utils.module_name(controller)}##{action}"
+  end
+
+  def name(%Plug.Conn{method: method, private: %{plug_route: {path, _fun}}}) do
+    "#{method} #{path}"
+  end
+
+  def name(_conn) do
+    nil
+  end
+
   defp headers(req_headers) do
     headers(req_headers, %{})
   end

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,8 @@ defmodule Appsignal.Plug.MixProject do
 
     [
       {:plug, plug_version},
-      {:appsignal, ">= 2.4.0 and < 3.0.0"},
+      {:appsignal, ">= 2.4.0 and < 3.0.0",
+       github: "appsignal/appsignal-elixir", branch: "metadata"},
       {:credo, "~> 1.2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},

--- a/mix.exs
+++ b/mix.exs
@@ -58,8 +58,7 @@ defmodule Appsignal.Plug.MixProject do
 
     [
       {:plug, plug_version},
-      {:appsignal, ">= 2.4.0 and < 3.0.0",
-       github: "appsignal/appsignal-elixir", branch: "metadata"},
+      {:appsignal, ">= 2.5.1 and < 3.0.0"},
       {:credo, "~> 1.2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},

--- a/test/appsignal_plug/metadata_test.exs
+++ b/test/appsignal_plug/metadata_test.exs
@@ -142,4 +142,18 @@ defmodule Appsignal.Plug.MetadataTest do
       assert Appsignal.Metadata.name(conn) == "GET /"
     end
   end
+
+  test "extracts the conn's category", %{conn: conn} do
+    assert Appsignal.Metadata.category(conn) == "call.plug"
+  end
+
+  describe "with a phoenix_endpoint" do
+    setup %{conn: conn} do
+      %{conn: Plug.Conn.put_private(conn, :phoenix_endpoint, Endpoint)}
+    end
+
+    test "extracts the conn's category", %{conn: conn} do
+      assert Appsignal.Metadata.category(conn) == "call.phoenix"
+    end
+  end
 end

--- a/test/appsignal_plug/metadata_test.exs
+++ b/test/appsignal_plug/metadata_test.exs
@@ -160,4 +160,8 @@ defmodule Appsignal.Plug.MetadataTest do
   test "extracts the conn's params", %{conn: conn} do
     assert Appsignal.Metadata.params(conn) == %{}
   end
+
+  test "extracts the conn's session data", %{conn: conn} do
+    assert Appsignal.Metadata.session(conn) == %{}
+  end
 end

--- a/test/appsignal_plug/metadata_test.exs
+++ b/test/appsignal_plug/metadata_test.exs
@@ -156,4 +156,8 @@ defmodule Appsignal.Plug.MetadataTest do
       assert Appsignal.Metadata.category(conn) == "call.phoenix"
     end
   end
+
+  test "extracts the conn's params", %{conn: conn} do
+    assert Appsignal.Metadata.params(conn) == %{}
+  end
 end

--- a/test/appsignal_plug/metadata_test.exs
+++ b/test/appsignal_plug/metadata_test.exs
@@ -98,4 +98,48 @@ defmodule Appsignal.Plug.MetadataTest do
       assert Appsignal.Metadata.metadata(conn)
     end
   end
+
+  test "does not extract the conn's name if unset", %{conn: conn} do
+    assert Appsignal.Metadata.name(conn) == nil
+  end
+
+  describe "when an appsignal_name is set" do
+    setup %{conn: conn} do
+      %{conn: Plug.Conn.put_private(conn, :appsignal_name, "appsignal_name")}
+    end
+
+    test "extracts the conn's name", %{conn: conn} do
+      assert Appsignal.Metadata.name(conn) == "appsignal_name"
+    end
+  end
+
+  describe "when phoenix_controller and phoenix_action are set" do
+    setup %{conn: conn} do
+      %{
+        conn:
+          conn
+          |> Plug.Conn.put_private(:phoenix_controller, "TestController")
+          |> Plug.Conn.put_private(:phoenix_action, "index")
+      }
+    end
+
+    test "extracts the conn's name", %{conn: conn} do
+      assert Appsignal.Metadata.name(conn) == "TestController#index"
+    end
+  end
+
+  describe "when method and plug_route are set" do
+    setup %{conn: conn} do
+      %{
+        conn:
+          conn
+          |> Map.put(:method, "GET")
+          |> Plug.Conn.put_private(:plug_route, {"/", nil})
+      }
+    end
+
+    test "extracts the conn's name", %{conn: conn} do
+      assert Appsignal.Metadata.name(conn) == "GET /"
+    end
+  end
 end

--- a/test/appsignal_plug_test.exs
+++ b/test/appsignal_plug_test.exs
@@ -446,15 +446,6 @@ defmodule Appsignal.PlugTest do
                Test.Span.get(:set_attribute)
     end
 
-    test "ignores Phoenix conns", %{span: span} do
-      assert Appsignal.Plug.set_conn_data(span, %Plug.Conn{
-               method: "GET",
-               private: %{phoenix_endpoint: AppsignalPhoenixExampleWeb.Endpoint}
-             }) == span
-
-      assert Test.Span.get(:set_name) == :error
-    end
-
     test "sets the span's parameters", %{span: span} do
       assert Appsignal.Plug.set_conn_data(span, %Plug.Conn{method: "GET", params: %{"id" => "4"}}) ==
                span

--- a/test/appsignal_plug_test.exs
+++ b/test/appsignal_plug_test.exs
@@ -480,34 +480,6 @@ defmodule Appsignal.PlugTest do
       %{"sample_data" => sample_data} = Appsignal.Span.to_map(span)
       assert ~s({"key":"value"}) == sample_data["session_data"]
     end
-
-    test "does not set unfetched session data", %{span: span} do
-      assert Appsignal.Plug.set_conn_data(span, %Plug.Conn{}) == span
-
-      %{"sample_data" => sample_data} = Appsignal.Span.to_map(span)
-      refute Map.has_key?(sample_data, "session_data")
-    end
-
-    test "does not set session data when send_session_data is set to false", %{span: span} do
-      config = Application.get_env(:appsignal, :config)
-      Application.put_env(:appsignal, :config, %{config | send_session_data: false})
-
-      try do
-        Appsignal.Plug.set_conn_data(span, %Plug.Conn{
-          method: "GET",
-          private: %{
-            plug_route: {"/", fn -> :ok end},
-            plug_session: %{key: "value"},
-            plug_session_fetch: :done
-          }
-        })
-      after
-        Application.put_env(:appsignal, :config, config)
-      end
-
-      %{"sample_data" => sample_data} = Appsignal.Span.to_map(span)
-      refute Map.has_key?(sample_data, "session_data")
-    end
   end
 
   test "handles requests with nil request headers" do


### PR DESCRIPTION
Part of https://github.com/appsignal/appsignal-elixir-phoenix/issues/57 is the Phoenix integration setting its own metadata. For this, the Plug integration needs to expose these values.

## To do

- [x] ⚠️ Before merging this, release a new version of AppSignal for Elixir which includes https://github.com/appsignal/appsignal-elixir/pull/813, and update the dependency to depend on that version in AppSignal for Plug