### PR TITLE
Use Utils.warning/1 instead of Logger.warning/1

### DIFF
--- a/.changesets/fix-logger-deprecation-warnings-on-elixir-1-15.md
+++ b/.changesets/fix-logger-deprecation-warnings-on-elixir-1-15.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix Logger deprecation warnings on Elixir 1.15

--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -37,7 +37,7 @@ defmodule Appsignal.Plug do
       use Plug.ErrorHandler
 
       def call(%Plug.Conn{private: %{appsignal_plug_instrumented: true}} = conn, opts) do
-        Logger.warn(
+        Appsignal.Utils.warning(
           "Appsignal.Plug was included twice, disabling Appsignal.Plug. Please only `use Appsignal.Plug` once."
         )
 

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule Appsignal.Plug.MixProject do
 
     [
       {:plug, plug_version},
-      {:appsignal, ">= 2.5.1 and < 3.0.0"},
+      {:appsignal, ">= 2.7.4 and < 3.0.0"},
       {:credo, "~> 1.2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},


### PR DESCRIPTION
Update the minimal version of the appsignal dependency to 2.7.4, which is the version that introduces the backwards compatible logging functions in Appsignal.Utils.

Then, use Appsignal.Utils.warning/1 in Appsignal.Phoenix.View and Appsignal.Phoenix.EventHandler to support Elixir 1.10 through 1.15.