### PR TITLE
Use `set_sample_data_if_nil` on span close

### DIFF
--- a/.changesets/fix-sample-data-being-overriden-by-plug-data.md
+++ b/.changesets/fix-sample-data-being-overriden-by-plug-data.md
@@ -1,0 +1,6 @@
+---
+bump: "patch"
+type: "fix"
+---
+
+Fix an issue in which sample data is overriden by Plug data when the span closes.

--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -108,9 +108,9 @@ defmodule Appsignal.Plug do
     span
     |> @span.set_name(Appsignal.Metadata.name(conn))
     |> @span.set_attribute("appsignal:category", Appsignal.Metadata.category(conn))
-    |> @span.set_sample_data("params", Appsignal.Metadata.params(conn))
-    |> @span.set_sample_data("environment", Appsignal.Metadata.metadata(conn))
-    |> @span.set_sample_data("session_data", Appsignal.Metadata.session(conn))
+    |> @span.set_sample_data_if_nil("params", Appsignal.Metadata.params(conn))
+    |> @span.set_sample_data_if_nil("environment", Appsignal.Metadata.metadata(conn))
+    |> @span.set_sample_data_if_nil("session_data", Appsignal.Metadata.session(conn))
   end
 
   @doc false

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule Appsignal.Plug.MixProject do
 
     [
       {:plug, plug_version},
-      {:appsignal, ">= 2.7.4 and < 3.0.0"},
+      {:appsignal, ">= 2.7.6 and < 3.0.0"},
       {:credo, "~> 1.2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},

--- a/test/appsignal_plug_test.exs
+++ b/test/appsignal_plug_test.exs
@@ -518,7 +518,7 @@ defmodule Appsignal.PlugTest do
   end
 
   defp sample_data(asserted_key, asserted_data) do
-    {:ok, sample_data} = Test.Span.get(:set_sample_data)
+    {:ok, sample_data} = Test.Span.get(:set_sample_data_if_nil)
 
     Enum.any?(sample_data, fn {%Span{}, key, data} ->
       key == asserted_key and data == asserted_data


### PR DESCRIPTION
Part of https://github.com/appsignal/appsignal-elixir/issues/862.

Before merging this, the version bound for the `appsignal` dependency needs to be updated to a version where `set_sample_data_if_nil` is implemented. This requires a release that contains the changes in [the Elixir integration PR](https://github.com/appsignal/appsignal-elixir/pull/866).

The tests are not passing on CI because they are ran against the latest release of the Elixir integration, which does not have the `set_sample_data_if_nil` function. They should pass after updating the version bound as described above.

---

When closing spans, use `set_sample_data_if_nil` instead of `set_sample_data` as to not override custom instrumentation set by the user while the span was open.