### PR TITLE
Lock Dialyxir to 1.3 for older Elixir versions

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -60,7 +60,7 @@ defmodule Appsignal.Plug.MixProject do
       {:plug, plug_version},
       {:appsignal, ">= 2.7.6 and < 3.0.0"},
       {:credo, "~> 1.2", only: [:dev, :test], runtime: false},
-      {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
+      {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
       {:telemetry, telemetry_version}
     ] ++ mime_dependency


### PR DESCRIPTION
Newer versions of Dialyxir use the
[Kernel.then/2](https://hexdocs.pm/elixir/Kernel.html#then/2) syntax introduced in Elixir 1.12.

Lock the package to 1.3, so we can run it on older versions while we still support them.

Related PR in appsignal-elixir repo:
https://github.com/appsignal/appsignal-elixir/pull/882

See also https://github.com/appsignal/appsignal-elixir/issues/881 for dropping those older versions.

[skip changeset]
[skip review]