### PR TITLE
Fix build by locking Hackney on OTP < 21

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,12 @@ defmodule Appsignal.Plug.MixProject do
     system_version = System.version()
     otp_version = System.otp_release()
 
+    hackney_version =
+      case otp_version >= "21" do
+        true -> "~> 1.6"
+        false -> "1.18.1"
+      end
+
     mime_dependency =
       if Mix.env() == :test || Mix.env() == :test_no_nif do
         case Version.compare(system_version, "1.10.0") do
@@ -62,7 +68,8 @@ defmodule Appsignal.Plug.MixProject do
       {:credo, "~> 1.2", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
-      {:telemetry, telemetry_version}
+      {:telemetry, telemetry_version},
+      {:hackney, hackney_version}
     ] ++ mime_dependency
   end
 end


### PR DESCRIPTION
It fails to build the `parse_trans` package on OTP < 21, because Hackney bumped its version lock between package version 1.18.1 and 1.18.2. The newer `parse_trans` version requires OTP > 21.

[skip changeset]
[skip review]