### PR TITLE
Lock credo to 1.7.6 on Elixir < 1.13

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -62,10 +62,16 @@ defmodule Appsignal.Plug.MixProject do
         _ -> ">= 1.1.0"
       end
 
+    credo_version =
+      case Version.compare(system_version, "1.13.0") do
+        :lt -> "1.7.6"
+        _ -> "~> 1.7"
+      end
+
     [
       {:plug, plug_version},
       {:appsignal, ">= 2.7.6 and < 3.0.0"},
-      {:credo, "~> 1.2", only: [:dev, :test], runtime: false},
+      {:credo, credo_version, only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
       {:telemetry, telemetry_version},


### PR DESCRIPTION
Credo 1.7.7 dropped support for Elixir versions below 1.13. This patch locks the credo version to 1.7.6 on any Elixir version before 1.13.