### PR TITLE
Don't use Appsignal.Utils for logging and compiling

### DIFF
--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -1,6 +1,5 @@
 defmodule Appsignal.Plug do
-  require Appsignal.Utils
-  @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+  @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
   @moduledoc """
   AppSignal's Plug instrumentation instruments calls to Plug applications to
@@ -28,16 +27,15 @@ defmodule Appsignal.Plug do
   defmacro __using__(_) do
     quote do
       require Logger
-      require Appsignal.Utils
       Appsignal.IntegrationLogger.debug("AppSignal.Plug attached to #{__MODULE__}")
 
-      @tracer Appsignal.Utils.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
-      @span Appsignal.Utils.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
+      @tracer Application.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
+      @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
       use Plug.ErrorHandler
 
       def call(%Plug.Conn{private: %{appsignal_plug_instrumented: true}} = conn, opts) do
-        Appsignal.Utils.warning(
+        Logger.warning(
           "Appsignal.Plug was included twice, disabling Appsignal.Plug. Please only `use Appsignal.Plug` once."
         )
 


### PR DESCRIPTION
Appsignal.Utils exposes warning/1 and compile_env/1 functions, which are wrappers to allow for using older Elixir versions. Because we're dropping any Elixir version under 1.11, these are no longer needed.

[skip changeset]