### PR TITLE
Run latest Elixir on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,8 @@ jobs:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: master
-          elixir-version: main
+          otp-version: 27.x
+          elixir-version: latest
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Check code formatting
@@ -34,8 +34,8 @@ jobs:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: master
-          elixir-version: main
+          otp-version: 27.x
+          elixir-version: latest
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Get dependencies
@@ -49,8 +49,8 @@ jobs:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: master
-          elixir-version: main
+          otp-version: 27.x
+          elixir-version: latest
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Get dependencies
@@ -92,8 +92,8 @@ jobs:
           - 26.x
           - 25.x
         include:
-          - elixir: main
-            otp: master
+          - elixir: latest
+            otp: 27.x
           - elixir: 1.16.x
             otp: 26.x
           - elixir: 1.15.x


### PR DESCRIPTION
Because of issues building Elixir main on OTP master, replace the main/master pair with 27.x/latest.

Related to appsignal/appsignal-elixir#954.

[skip changeset]