### PR TITLE
Add Elixir main to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,6 +92,8 @@ jobs:
           - 26.x
           - 25.x
         include:
+          - elixir: main
+            otp: 27.x
           - elixir: latest
             otp: 27.x
           - elixir: 1.16.x


### PR DESCRIPTION
This patch restores the Elixir main version on CI.

[skip changeset]