### PR TITLE
Remove Hackney dependency

### DIFF
--- a/.changesets/remove-hackney-dependency--the-integration-now-uses-finch-instead-.md
+++ b/.changesets/remove-hackney-dependency--the-integration-now-uses-finch-instead-.md
@@ -1,0 +1,6 @@
+---
+bump: minor
+type: change
+---
+
+Remove Hackney dependency. The integration now uses Finch instead.

--- a/mix.exs
+++ b/mix.exs
@@ -34,12 +34,6 @@ defmodule Appsignal.Plug.MixProject do
     system_version = System.version()
     otp_version = System.otp_release()
 
-    hackney_version =
-      case otp_version >= "21" do
-        true -> "~> 1.6"
-        false -> "1.18.1"
-      end
-
     mime_dependency =
       if Mix.env() == :test || Mix.env() == :test_no_nif do
         case Version.compare(system_version, "1.10.0") do
@@ -70,12 +64,11 @@ defmodule Appsignal.Plug.MixProject do
 
     [
       {:plug, plug_version},
-      {:appsignal, ">= 2.7.6 and < 3.0.0"},
+      {:appsignal, ">= 2.15.0 and < 3.0.0"},
       {:credo, credo_version, only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
-      {:telemetry, telemetry_version},
-      {:hackney, hackney_version}
+      {:telemetry, telemetry_version}
     ] ++ mime_dependency
   end
 end


### PR DESCRIPTION
The Elixir integration now uses Finch instead of Hackney since 2.15.0