### PR TITLE
Ensure spans in requests with errors aren't double-closed

### DIFF
--- a/.changesets/ensure-spans-in-requests-with-errors-aren-t-double-closed.md
+++ b/.changesets/ensure-spans-in-requests-with-errors-aren-t-double-closed.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Ensure spans in requests with errors aren't double-closed

--- a/test/appsignal_plug_test.exs
+++ b/test/appsignal_plug_test.exs
@@ -114,11 +114,7 @@ defmodule Appsignal.PlugTest do
     end
 
     test "creates a root span" do
-      assert {:ok, [{_, nil}]} = Test.Tracer.get(:create_span)
-    end
-
-    test "set's the span's namespace" do
-      assert {:ok, [{%Span{}, "http_request"}]} = Test.Span.get(:set_namespace)
+      assert {:ok, [{"http_request", nil}]} = Test.Tracer.get(:create_span)
     end
 
     test "sets the span's name" do


### PR DESCRIPTION
Since
https://github.com/appsignal/appsignal-elixir/commit/d218b4054f7c5accb94d07d215817ddc9d0b3a3c, the instrument/1 function automatically closes the created span. This caused issues with the Plug integration, which assumed spans weren't closed.

This patch moves off instrument/1 in the Plug integration by starting and closing the span itself. Because it now opens the span itself in the "http_request" namespace, it no longer has to set the namespace.