### PR TITLE
Run CI workflow for Pull Requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         elixir:
           - 1.17.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,15 @@
-name: CI
+name: Elixir Plug package CI
 
 on:
-  push: {}
+  push:
+    branches:
+    - main
+    - develop
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
   schedule:
     - cron: "0 0 * * 1-5"
 


### PR DESCRIPTION
For GitHub Actions, we need to specify the PR event to run it for PRs from outside contributors.

[skip changeset]
[skip review]