### PR TITLE
Remove unnecessary Plug.ErrorHandler from Plug

### DIFF
--- a/.changesets/restore-normal-error-reporting-behavior.md
+++ b/.changesets/restore-normal-error-reporting-behavior.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Restore normal error reporting behavior by removing the default included `Plug.ErrorHandler` in the `Appsignal.Plug` module. It will now longer render a page with HTTP status 500 and the response body "Something went wrong".

--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -32,8 +32,6 @@ defmodule Appsignal.Plug do
       @tracer Application.compile_env(:appsignal, :appsignal_tracer, Appsignal.Tracer)
       @span Application.compile_env(:appsignal, :appsignal_span, Appsignal.Span)
 
-      use Plug.ErrorHandler
-
       def call(%Plug.Conn{private: %{appsignal_plug_instrumented: true}} = conn, opts) do
         Logger.warning(
           "Appsignal.Plug was included twice, disabling Appsignal.Plug. Please only `use Appsignal.Plug` once."


### PR DESCRIPTION
I don't think we need this. Our own error handler logic, the try-catch in the `call` function does all the error handling we need.

By including it, we change the behavior of errors that occur in requests, because the `Plug.ErrorHandler`'s default implementation makes it return a response with status 500 and a body that says "Something went wrong".

Source:
https://github.com/elixir-plug/plug/blob/1947edc8171f923ecc262efba6a0946264fa5582/lib/plug/error_handler.ex#L66

Closes #54