### PR TITLE
Test against the latest Plug versions on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
 
   lint_format:
     runs-on: ubuntu-latest
+    env:
+      PLUG_VERSION: "~> 1.18"
     steps:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
@@ -38,6 +40,8 @@ jobs:
 
   lint_credo:
     runs-on: ubuntu-latest
+    env:
+      PLUG_VERSION: "~> 1.18"
     steps:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
@@ -53,6 +57,8 @@ jobs:
 
   lint_compile:
     runs-on: ubuntu-latest
+    env:
+      PLUG_VERSION: "~> 1.18"
     steps:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
@@ -68,6 +74,8 @@ jobs:
 
   lint_dialyzer:
     runs-on: ubuntu-latest
+    env:
+      PLUG_VERSION: "~> 1.18"
     steps:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
@@ -100,24 +108,37 @@ jobs:
           - 27.x
           - 26.x
           - 25.x
+        plug:
+          - "~> 1.18"
+          - "~> 1.17"
         include:
           - elixir: main
             otp: 27.x
+            plug: "~> 1.18"
           - elixir: latest
             otp: 27.x
+            plug: "~> 1.18"
           - elixir: 1.16.x
             otp: 26.x
+            plug: "~> 1.17"
           - elixir: 1.15.x
             otp: 26.x
+            plug: "~> 1.17"
           - elixir: 1.14.x
             otp: 25.x
+            plug: "~> 1.17"
           - elixir: 1.13.x
             otp: 24.x
+            plug: "~> 1.17"
           - elixir: 1.12.x
             otp: 24.x
+            plug: "~> 1.17"
           - elixir: 1.11.x
             otp: 24.x
+            plug: "~> 1.17"
 
+    env:
+      PLUG_VERSION: ${{matrix.plug}}
     steps:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1

--- a/mix.exs
+++ b/mix.exs
@@ -51,9 +51,16 @@ defmodule Appsignal.Plug.MixProject do
       end
 
     plug_version =
-      case Version.compare(system_version, "1.10.0") do
-        :lt -> ">= 1.1.0 and < 1.14.0"
-        _ -> ">= 1.1.0"
+      case {System.get_env("CI"), System.get_env("PLUG_VERSION")} do
+        {"true", nil} ->
+          raise "PLUG_VERSION environment variable must be set on CI"
+
+        {_, version} ->
+          version ||
+            case Version.compare(system_version, "1.10.0") do
+              :lt -> ">= 1.1.0 and < 1.14.0"
+              _ -> ">= 1.18.0"
+            end
       end
 
     credo_version =


### PR DESCRIPTION
Looks like we don't test against different versions of Plug. Add the Plug version to the test matrix.

[skip changeset]
[skip review]