### PR TITLE
Fix missing metadata on successful requests

### DIFF
--- a/.changesets/fix-success-trace-flushing.md
+++ b/.changesets/fix-success-trace-flushing.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: fix
+---
+
+Fix successful request traces being dropped by the extension.

--- a/lib/appsignal_plug.ex
+++ b/lib/appsignal_plug.ex
@@ -58,9 +58,8 @@ defmodule Appsignal.Plug do
             :erlang.raise(kind, reason, stack)
         else
           conn ->
-            @tracer.close_span(span)
-
             _ = Appsignal.Plug.set_conn_data(span, conn)
+            @tracer.close_span(span)
             Plug.Conn.put_private(conn, :appsignal_plug_instrumented, true)
         end
       end


### PR DESCRIPTION
Fixes #59.

Fix an issue where metadata is not set on successful requests, causing the extension to drop the traces for those requests.