### PR TITLE
Fix `PLUG_VERSION` requirement on CI

### DIFF
--- a/.changesets/fix-ci-build-failure.md
+++ b/.changesets/fix-ci-build-failure.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+type: fix
+---
+
+Fix an issue where the package fails to build in customer's CI environments
+due to a required `PLUG_VERSION` environment flag on CI. 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
   lint_format:
     runs-on: ubuntu-latest
     env:
-      PLUG_VERSION: "~> 1.18"
+      _APPSIGNAL_CI_PLUG_VERSION: "~> 1.18"
     steps:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
@@ -44,7 +44,7 @@ jobs:
   lint_credo:
     runs-on: ubuntu-latest
     env:
-      PLUG_VERSION: "~> 1.18"
+      _APPSIGNAL_CI_PLUG_VERSION: "~> 1.18"
     steps:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
@@ -61,7 +61,7 @@ jobs:
   lint_compile:
     runs-on: ubuntu-latest
     env:
-      PLUG_VERSION: "~> 1.18"
+      _APPSIGNAL_CI_PLUG_VERSION: "~> 1.18"
     steps:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
@@ -78,7 +78,7 @@ jobs:
   lint_dialyzer:
     runs-on: ubuntu-latest
     env:
-      PLUG_VERSION: "~> 1.18"
+      _APPSIGNAL_CI_PLUG_VERSION: "~> 1.18"
     steps:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1
@@ -187,7 +187,7 @@ jobs:
             plug: "~> 1.17.0"
 
     env:
-      PLUG_VERSION: ${{matrix.plug}}
+      _APPSIGNAL_CI_PLUG_VERSION: ${{matrix.plug}}
     steps:
       - name: Set up Erlang and Elixir
         uses: erlef/setup-beam@v1

--- a/mix.exs
+++ b/mix.exs
@@ -51,17 +51,11 @@ defmodule Appsignal.Plug.MixProject do
       end
 
     plug_version =
-      case {System.get_env("CI"), System.get_env("PLUG_VERSION")} do
-        {"true", nil} ->
-          raise "PLUG_VERSION environment variable must be set on CI"
-
-        {_, version} ->
-          version ||
-            case Version.compare(system_version, "1.10.0") do
-              :lt -> ">= 1.1.0 and < 1.14.0"
-              _ -> ">= 1.18.0"
-            end
-      end
+      System.get_env("_APPSIGNAL_CI_PLUG_VERSION") ||
+        case Version.compare(system_version, "1.10.0") do
+          :lt -> ">= 1.1.0 and < 1.14.0"
+          _ -> ">= 1.18.0"
+        end
 
     credo_version =
       case Version.compare(system_version, "1.13.0") do


### PR DESCRIPTION
Fixes #61.

This requirement should've never applied to any environment where `CI` is set, just our own.

Modify our setup to match what appsignal/appsignal-elixir-phoenix does, where the installation falls back to a default value when the environment variable is unset.