### PR TITLE
Cap transitive Finch on Elixir < 1.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,12 +179,14 @@ jobs:
           - elixir: 1.12.x
             otp: 24.x
             plug: "~> 1.17.0"
+          # Plug 1.18.2 and 1.17.1 use `then/2`, which requires Elixir 1.12+.
+          # Cap Plug below those on Elixir 1.11.
           - elixir: 1.11.x
             otp: 24.x
-            plug: "~> 1.18.0"
+            plug: "~> 1.18.0 and < 1.18.2"
           - elixir: 1.11.x
             otp: 24.x
-            plug: "~> 1.17.0"
+            plug: "~> 1.17.0 and < 1.17.1"
 
     env:
       _APPSIGNAL_CI_PLUG_VERSION: ${{matrix.plug}}

--- a/mix.exs
+++ b/mix.exs
@@ -63,6 +63,16 @@ defmodule Appsignal.Plug.MixProject do
         _ -> "~> 1.7"
       end
 
+    # Finch 0.22+ requires Elixir 1.15+. On older Elixir versions, cap the
+    # version of Finch that's pulled in transitively through the AppSignal
+    # package so it can still compile. On newer Elixir versions Finch is left
+    # out of the dependency list entirely, so it stays a transitive dependency.
+    finch_dependency =
+      case Version.compare(system_version, "1.15.0") do
+        :lt -> [{:finch, ">= 0.19.0 and < 0.22.0"}]
+        _ -> []
+      end
+
     [
       {:plug, plug_version},
       {:appsignal, ">= 2.15.0 and < 3.0.0"},
@@ -70,6 +80,6 @@ defmodule Appsignal.Plug.MixProject do
       {:dialyxir, "~> 1.3.0", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
       {:telemetry, telemetry_version}
-    ] ++ mime_dependency
+    ] ++ mime_dependency ++ finch_dependency
   end
 end


### PR DESCRIPTION
Scheduled CI on `main` has been red because two upstream releases dropped support for old Elixir:

- **Finch 0.22+** needs Elixir 1.15+. It's pulled in transitively via the AppSignal package, uncapped, so CI resolves to the latest and fails to compile on Elixir 1.11-1.14.
- **Plug 1.17.1 / 1.18.2** use `then/2` (Elixir 1.12+), so they fail to compile on Elixir 1.11.

## Fix

- Cap Finch to `< 0.22` on Elixir < 1.15, mirroring what `appsignal-elixir` already does.
- Pin Plug below 1.17.1 / 1.18.2 in the Elixir 1.11 CI matrix entries.

This is CI-only. Releases are published from the latest Elixir, where these caps don't apply, so the published package is unchanged (hence no changeset).